### PR TITLE
Add new flex features & data samples

### DIFF
--- a/docs/getting_started/features/flexible_services.md
+++ b/docs/getting_started/features/flexible_services.md
@@ -18,7 +18,9 @@ This can be specified either in `routes.txt`, indicating that riders can be pick
 ??? note "Sample Data"
 
     <p style="font-size:16px">
-    The following sample shows two ways of representing continuous stop, the first one using routes.txt to specify a vehicle that can stop for pick-up and/or drop off at any point along the total length of the route. Secondly, using stop_times.txt to define a specific segment between certain stops where the rider can request to be picked-up and/or dropped off.
+    The following sample shows two ways of representing Continuous Stop. 
+The first sample shows that pickups and dropoffs are allowed at any point along route `RA`.
+The second sample shows that pickups and dropoffs are allowed between the third and fifth stops of trip `AWE1`, accomplished by assigning `continuous_pickup` and `continuous_drop_off` values to `stop_sequence=3` and `stop_sequence=4`.
 
     </p>
     !!! note ""

--- a/docs/getting_started/features/flexible_services.md
+++ b/docs/getting_started/features/flexible_services.md
@@ -5,7 +5,281 @@ Flexible services, also called demand-responsibe services, are services that do 
 
 Continuous Stops is used when riders can be picked up and/or dropped off between scheduled stops all along the route or on specific sections of it. This is defined in `routes.txt`, indicating that the rider can be picked up of dropped off the transit vehicle at any point along the vehicle’s travel path, on every trip of the route.
 
+**Pre-requirement**: 
+
+- [Base features](/getting_started/features/base)
+
 | Files included                   | Fields included   |
 |----------------------------------|-------------------|
 |[stop_times.txt](/schedule/reference/#stop_timestxt)|`continuous_pickup`, `continuous_drop_off` |
 |[routes.txt](/schedule/reference/#routestxt)|`continuous_pickup`, `continuous_drop_off` |
+
+??? note "Sample Data"
+
+    <p style="font-size:16px">
+    The following sample shows two ways of representing continuous stop, the first one using routes.txt to specify a vehicle that can stop for pick-up and/or drop off at any point along the total length of the route. Secondly, using stop_times.txt to define a specific segment between certain stops where the rider can request to be picked-up and/or dropped off.
+
+    </p>
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#routestxt"><b>routes.txt</b></a> <br>
+        </p>
+
+        | route_id | route_short_name | route_type | continuous_pickup | continuous_drop_off |
+        |----------|------------------|------------|-------------------|---------------------|
+        | RA       |               17 |          3 |                 0 |                   0 |
+
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#stop_timestxt"><b>stop_times.txt</b></a> <br>
+        </p>
+
+        | trip_id | arrival_time | departure_time | stop_id | stop_sequence | continuous_pickup | continuous_drop_off |
+        |---------|--------------|----------------|---------|---------------|-------------------|---------------------|
+        | AWE1    |      6:10:00 |        6:10:00 | TAS001  |             1 |                   |                     |
+        | AWE1    |      6:14:00 |        6:14:00 | TAS002  |             2 |                   |                     |
+        | AWE1    |      6:20:00 |        6:20:00 | TAS003  |             3 |                 0 |                   0 |
+        | AWE1    |      6:23:00 |        6:23:00 | TAS004  |             4 |                 0 |                   0 |
+        | AWE1    |      6:25:00 |        6:25:00 | TAS005  |             5 |                   |                     |
+
+##  Booking rules
+
+Booking rules can be used to enable users to reserve a trip within a demand-responsive. These rules outline the necessary prerequisites for successful bookings and provide contact information where users can make trip reservations. This should be used in conjunction with the On-demand services feature.
+
+**Pre-requirement**: 
+
+- [Base features](/getting_started/features/base)
+
+| Files included                   | Fields included   |
+|----------------------------------|-------------------|
+|[booking_rules.txt](/schedule/reference/#booking_rulestxt)|`booking_rule_id`, `booking_type`, `prior_notice_duration_min`, `prior_notice_duration_max`, `prior_notice_last_day`, `prior_notice_last_time`, `prior_notice_start_day`, `prior_notice_start_time`, `prior_notice_service_id`, `message`, `pickup_message`, `drop_off_message`, `phone_number`, `info_url`, `booking_url` |
+
+??? note "Sample Data"
+
+    <p style="font-size:16px">
+    The following sample defines two different set of booking rules, the first one for trips that must be booked at least one day in advance (before 1PM) and no more than 14 days prior, and a second one for trips that can be booked at least 45 minutes prior to the trip and no more than 5 hours before.
+
+    </p>
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#booking_rulestxt"><b>booking_rules.txt</b></a> <br>
+        </p>
+
+        | booking_rule_id | booking_type | prior_notice_duration_min | prior_notice_duration_max | prior_notice_last_day | prior_notice_last_time | prior_notice_start_day | prior_notice_start_time | prior_notice_service_id | message                                                                                                                                            | pickup_message | drop_off_message | phone_number   | info_url             | booking_url             |
+        |-----------------|--------------|---------------------------|---------------------------|-----------------------|------------------------|------------------------|-------------------------|-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|----------------|------------------|----------------|----------------------|-------------------------|
+        | route_br_1818   |            2 |                           |                           |                     1 |                  13:00 |                     14 |                    9:00 |                         | To request a ride, call 123-111-2233 before 1pm at least one business day ahead of your trip. You can book trips up to 14 business days in advace. |                |                  | (123)-111-2233 | flexservice.org/info | flexservice.org/booking |
+        | route_br_4545   |            1 |                        45 |                       300 |                       |                        |                        |                         |                         | To request a ride, use the official booking system in our website, trips must be booked at least 45 min in advance                                 |                |                  | (123)-111-2233 | flexservice.org/info | flexservice.org/booking |
+
+
+## Predefined routes with deviation
+
+Predefined routes with deviation can be used to model flexible services where vehicles can briefly deviate from a specific route to pick up users that booked a trip within a specific area along the route. This uses a combination of traditional stops (like a regular scheduled service) and zones using `locations.geojson`.
+
+**Pre-requirement**: 
+
+- [Base features](/getting_started/features/base)
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking
+
+| Files included                   | Fields included   |
+|----------------------------------|-------------------|
+|[stop_times.txt](/documentation/schedule/reference/#stop_timestxt)|`location_id`, `start_pickup_drop_off_window`, `end_pickup_drop_off_window`, `pickup_booking_rule_id`, `drop_off_booking_rule_id`|
+|[locations.geojson](/documentation/schedule/reference/#locationsgeojson)|`Type`, `Features`, `Features:Type`, `Features:Id`, `Features:Properties`, `Features:Properties:Stop_name`, `Features:Properties:Stop_description`, `Features:Geometry`, `Features:Geometry:Type`, `Features:Geometry:Coordinates` |
+
+??? note "Sample Data"
+
+    <p style="font-size:16px">
+    The following sample defines a trip with three fixed stops that can also drop-off passengers anywhere within specific areas defined between the fixed stops.
+    </p>
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#stop_timestxt"><b>stop_times.txt</b></a> <br>
+        </p>
+
+        | trip_id  | arrival_time | departure_time | stop_id | location_id           | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | shape_dist_traveled | pickup_booking_rule_id | drop_off_booking_rule_id |
+        |----------|--------------|----------------|---------|-----------------------|---------------|------------------------------|----------------------------|-------------|---------------|---------------------|------------------------|--------------------------|
+        | 4545_001 |     10:00:00 |       10:00:00 | S50122  |                       |             1 |                              |                            |             |               |                   0 |                        |                          |
+        | 4545_001 |              |                |         | zone_S50122_to_S50123 |             2 |                     10:00:00 |                   10:06:00 |           1 |             3 |                     | br_1234                | br_1234                  |
+        | 4545_001 |     10:06:00 |       10:06:00 | S50123  |                       |             3 |                              |                            |             |               |                 983 |                        |                          |
+        | 4545_001 |              |                |         | zone_S50123_to_S50124 |             4 |                     10:06:00 |                   10:15:00 |           1 |             3 |                     | br_1234                | br_1234                  |
+        | 4545_001 |     10:15:00 |       10:15:00 | S50124  |                       |             5 |                              |                            |             |               |                2109 |                        |                          |
+
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#locationsgeojson"><b>locations.geojson</b></a> <br>
+        </p>
+
+        ~~~
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "id": "zone_S50122_to_S50123",
+              "type": "Feature",
+              "geometry": {
+                "type": "Polygon",
+                # Simplified, only presenting 3 coordinates here.
+                "coordinates": [
+                  [
+                    [
+                      -73.575952,
+                      45.514974
+                    ],
+                    [
+                      -73.577314,
+                      45.513433
+                    ],
+                    [
+                      -73.569794,
+                      45.5098370
+                    ]
+                  ]
+                ]
+              },
+              "properties": {}
+            },
+        {
+              "id": "zone_S50123_to_S50124",
+              "type": "Feature",
+              "geometry": {
+                "type": "Polygon",
+                # Simplified, only presenting 3 coordinates here.
+                "coordinates": [
+                  [
+                    [
+                      -73.561332,
+                      45.5085599
+                    ],
+                    [
+                     -73.5701298,
+                      45.5124057
+                    ],
+                    [
+                      -73.571302,
+                      45.5105563
+                    ]
+                  ]
+                ]
+              },
+              "properties": {}
+            }
+           ]
+        } 
+        ~~~
+
+## On-demand services with zones
+
+On-demand services with zones is used to model demand responsive services that allow pick up and/or drop off at any location within a specific area for users that book a trip. These areas are defined using `locations.geojson` so it does not require the use of `stops.txt`, nor `stop_times.arrival_time` & `stop_times.departure_time`.
+
+**Pre-requirement**: 
+
+- [Base features](/getting_started/features/base)
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking 
+
+| Files included                   | Fields included   |
+|----------------------------------|-------------------|
+|[stop_times.txt](/documentation/schedule/reference/#stop_timestxt)|`location_id`, `start_pickup_drop_off_window`, `end_pickup_drop_off_window`, `pickup_booking_rule_id`, `drop_off_booking_rule_id`|
+|[locations.geojson](/documentation/schedule/reference/#locationsgeojson)|`Type`, `Features`, `Features:Type`, `Features:Id`, `Features:Properties`, `Features:Properties:Stop_name`, `Features:Properties:Stop_description`, `Features:Geometry`, `Features:Geometry:Type`, `Features:Geometry:Coordinates` |
+
+??? note "Sample Data"
+
+    <p style="font-size:16px">
+    The following sample defines a service that can pick-up and drop off pre-booked riders anywhere between a specific area between 9am and 6pm.
+    </p>
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#stop_timestxt"><b>stop_times.txt</b></a> <br>
+        </p>
+
+        | trip_id  | location_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id |
+        |----------|-------------|---------------|------------------------------|----------------------------|-------------|---------------|------------------------|--------------------------|
+        | 2708_001 | area_001    |             1 |                      9:00:00 |                   18:00:00 |           2 |             1 | br_3289                | br_3289                  |
+        | 2708_001 | area_001    |             2 |                      9:00:00 |                   18:00:00 |           1 |             2 | br_3289                | br_3289                  |
+
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#locationsgeojson"><b>locations.geojson</b></a> <br>
+        </p>
+
+        ~~~
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "id": "area_001",
+              "type": "Feature",
+              "geometry": {
+                "type": "Polygon",
+                # Simplified, only presenting 3 coordinates here.
+                "coordinates": [
+                  [
+                    [
+                      -73.644437,
+                      45.5023960
+                    ],
+                    [
+                      -73.641593,
+                      45.5054392
+                    ],
+                    [
+                      -73.636580,
+                      45.5081683
+                    ]
+                  ]
+                ]
+              },
+              "properties": {}
+            }
+          ]
+        }
+        ~~~
+
+## On-demand services with fixed stops
+On-demand services with fixed stops is used to model demand responsive services that allow pick up and/or drop off at any location within a group of stops for users that book a trip. These groups of stops are defined using `location_groups.txt` and `location_group_stops.txt`
+
+**Pre-requirement**: 
+
+- [Base features](/getting_started/features/base)
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking
+
+| Files included                   | Fields included   |
+|----------------------------------|-------------------|
+|[stop_times.txt](/documentation/schedule/reference/#stop_timestxt)|`location_group_id`, `start_pickup_drop_off_window`, `end_pickup_drop_off_window`, `pickup_booking_rule_id`, `drop_off_booking_rule_id`|
+|[location_groups.txt](/documentation/schedule/reference/#location_groupstxt)|`location_group_id`, `location_group_name`|
+|[location_group_stops.txt](/documentation/schedule/reference/#location_group_stopstxt)|`location_group_id`, `stop_id`|
+
+??? note "Sample Data"
+
+    <p style="font-size:16px">
+    The following sample defines a service that can pick-up and drop off pre-booked riders at 4 different stops between 7am and 10am.
+
+    </p>
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#location_groupstxt"><b>location_groups.txt</b></a> <br>
+        </p>
+
+        | location_group_id | location_group_name           |
+        |-------------------|-------------------------------|
+        | r27_stops         | Yellow Borough Route 27 stops |
+
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#location_group_stopstxt"><b>location_group_stops.txt</b></a> <br>
+        </p>
+
+        | location_group_id | stop_id |
+        |-------------------|---------|
+        | r27_stops         | syb029  |
+        | r27_stops         | syb030  |
+        | r27_stops         | syb031  |
+        | r27_stops         | syb032  |
+
+    !!! note ""
+        <p style="font-size:16px">
+        <a href="/documentation/schedule/reference/#stop_timestxt"><b>stop_times.txt</b></a> <br>
+        </p>
+
+        | trip_id  | location_group_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id |
+        |----------|-------------------|---------------|------------------------------|----------------------------|-------------|---------------|------------------------|--------------------------|
+        | 2714_002 | r27_stops         |             1 |                      7:00:00 |                   10:00:00 |           2 |             1 | br_5478                | br_5478                  |
+        | 2714_002 | r27_stops         |             2 |                      7:00:00 |                   10:00:00 |           1 |             2 | br_5478                | br_5478                  |

--- a/docs/getting_started/features/flexible_services.md
+++ b/docs/getting_started/features/flexible_services.md
@@ -54,7 +54,7 @@ This can be specified either in `routes.txt`, indicating that riders can be pick
 
 ##  Booking Rules
 
-Booking rules can be used to enable users to reserve a trip on a demand-responsive service. These rules outline the necessary prerequisites for successful bookings and provide contact information where users can make trip reservations. This should be used in conjunction with the On-demand services feature.
+Booking rules can be used to enable users to reserve a trip on a demand-responsive service. These rules outline the necessary prerequisites for successful bookings and provide contact information where users can make trip reservations. This feature should be used in conjunction with [Predefined Routes With Deviation](/getting_started/features/flexible_services/#predefined-routes-with-deviation), [Zone-based Demand Responsive Services](/getting_started/features/flexible_services/#zone-based-demand-responsive-services) and [Fixed-Stops Demand Responsive Services](/getting_started/features/flexible_services/#fixed-stops-demand-responsive-services) features, if such services require booking.
 
 **Pre-requirement**: 
 
@@ -81,9 +81,9 @@ Booking rules can be used to enable users to reserve a trip on a demand-responsi
         | route_br_4545   |            1 |                        45 |                       300 |                       |                        |                        |                         |                         | To request a ride, use the official booking system in our website, trips must be booked at least 45 min in advance                                 |                |                  | (123)-111-2233 | flexservice.org/info | flexservice.org/booking |
 
 
-## Predefined routes with deviation
+## Predefined Routes With Deviation
 
-Predefined routes with deviation can be used to model flexible services where vehicles can briefly deviate from a specific route to pick up users that booked a trip within a specific area along the route. This uses a combination of traditional stops (like a regular scheduled service) and zones using `locations.geojson`.
+Predefined Routes With Deviation can be used to model flexible services where vehicles can briefly deviate from a specific route to pick up users that booked a trip within a specific area along the route. This uses a combination of traditional stops (like a regular scheduled service) and zones using `locations.geojson`.
 
 **Pre-requirement**: 
 

--- a/docs/getting_started/features/flexible_services.md
+++ b/docs/getting_started/features/flexible_services.md
@@ -3,7 +3,8 @@ Flexible services, also called demand-responsibe services, are services that do 
 
 ## Continuous stops
 
-Continuous Stops is used when riders can be picked up and/or dropped off between scheduled stops all along the route or on specific sections of it. This is defined in `routes.txt`, indicating that the rider can be picked up of dropped off the transit vehicle at any point along the vehicle’s travel path, on every trip of the route.
+Continuous Stops is used when riders can be picked up and/or dropped off between scheduled stops. 
+This can be specified either in `routes.txt`, indicating that riders can be picked up or dropped off at any point along the vehicle’s travel path for every trip of the route, or in `stop_times.txt` for a specific section of a route.  
 
 **Pre-requirement**: 
 

--- a/docs/getting_started/features/flexible_services.md
+++ b/docs/getting_started/features/flexible_services.md
@@ -1,7 +1,7 @@
 # Flexible services
 Flexible services, also called demand-responsibe services, are services that do not follow the common behavior of scheduled and/or fixed  service. 
 
-## Continuous stops
+## Continuous Stops
 
 Continuous Stops is used when riders can be picked up and/or dropped off between scheduled stops. 
 This can be specified either in `routes.txt`, indicating that riders can be picked up or dropped off at any point along the vehicle’s travel path for every trip of the route, or in `stop_times.txt` for a specific section of a route.  
@@ -19,8 +19,15 @@ This can be specified either in `routes.txt`, indicating that riders can be pick
 
     <p style="font-size:16px">
     The following sample shows two ways of representing Continuous Stop. 
-The first sample shows that pickups and dropoffs are allowed at any point along route `RA`.
-The second sample shows that pickups and dropoffs are allowed between the third and fifth stops of trip `AWE1`, accomplished by assigning `continuous_pickup` and `continuous_drop_off` values to `stop_sequence=3` and `stop_sequence=4`.
+    </p>
+    
+    <p style="font-size:16px">
+    The first sample shows that pickups and dropoffs are allowed at any point along route `RA`.
+     </p>
+
+    <p style="font-size:16px">
+    The second sample shows that pickups and dropoffs are allowed between the third and fifth stops of trip `AWE1`, accomplished by assigning `continuous_pickup` and `continuous_drop_off` values to `stop_sequence=3` and `stop_sequence=4`.
+    </p>
 
     </p>
     !!! note ""
@@ -45,9 +52,9 @@ The second sample shows that pickups and dropoffs are allowed between the third 
         | AWE1    |      6:23:00 |        6:23:00 | TAS004  |             4 |                 0 |                   0 |
         | AWE1    |      6:25:00 |        6:25:00 | TAS005  |             5 |                   |                     |
 
-##  Booking rules
+##  Booking Rules
 
-Booking rules can be used to enable users to reserve a trip within a demand-responsive. These rules outline the necessary prerequisites for successful bookings and provide contact information where users can make trip reservations. This should be used in conjunction with the On-demand services feature.
+Booking rules can be used to enable users to reserve a trip on a demand-responsive service. These rules outline the necessary prerequisites for successful bookings and provide contact information where users can make trip reservations. This should be used in conjunction with the On-demand services feature.
 
 **Pre-requirement**: 
 
@@ -60,7 +67,7 @@ Booking rules can be used to enable users to reserve a trip within a demand-resp
 ??? note "Sample Data"
 
     <p style="font-size:16px">
-    The following sample defines two different set of booking rules, the first one for trips that must be booked at least one day in advance (before 1PM) and no more than 14 days prior, and a second one for trips that can be booked at least 45 minutes prior to the trip and no more than 5 hours before.
+    The following sample shows two different set of booking rules, the first one for trips that must be booked at least one day in advance (before 1PM) and no more than 14 days prior, and a second one for trips that can be booked at least 45 minutes prior to the trip and no more than 5 hours before.
 
     </p>
     !!! note ""
@@ -81,7 +88,7 @@ Predefined routes with deviation can be used to model flexible services where ve
 **Pre-requirement**: 
 
 - [Base features](/getting_started/features/base)
-- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) if the service requires booking
 
 | Files included                   | Fields included   |
 |----------------------------------|-------------------|
@@ -91,7 +98,7 @@ Predefined routes with deviation can be used to model flexible services where ve
 ??? note "Sample Data"
 
     <p style="font-size:16px">
-    The following sample defines a trip with three fixed stops that can also drop-off passengers anywhere within specific areas defined between the fixed stops.
+    The following sample shows a trip with three fixed stops that can also drop-off passengers anywhere within specific areas defined between the fixed stops.
     </p>
     !!! note ""
         <p style="font-size:16px">
@@ -169,14 +176,14 @@ Predefined routes with deviation can be used to model flexible services where ve
         } 
         ~~~
 
-## On-demand services with zones
+## Zone-based Demand Responsive Services
 
-On-demand services with zones is used to model demand responsive services that allow pick up and/or drop off at any location within a specific area for users that book a trip. These areas are defined using `locations.geojson` so it does not require the use of `stops.txt`, nor `stop_times.arrival_time` & `stop_times.departure_time`.
+Zone-based Demand Responsive Services is used to model services that allow pick up and/or drop off at any location within a specific area for users that book a trip. These areas are defined using `locations.geojson` so it does not require the use of `stops.txt`, nor `stop_times.arrival_time` & `stop_times.departure_time`.
 
 **Pre-requirement**: 
 
 - [Base features](/getting_started/features/base)
-- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking 
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) if the service requires booking 
 
 | Files included                   | Fields included   |
 |----------------------------------|-------------------|
@@ -186,7 +193,7 @@ On-demand services with zones is used to model demand responsive services that a
 ??? note "Sample Data"
 
     <p style="font-size:16px">
-    The following sample defines a service that can pick-up and drop off pre-booked riders anywhere between a specific area between 9am and 6pm.
+    The following sample shows a service that can pick-up and drop off pre-booked riders anywhere between a specific area between 9am and 6pm.
     </p>
     !!! note ""
         <p style="font-size:16px">
@@ -236,13 +243,13 @@ On-demand services with zones is used to model demand responsive services that a
         }
         ~~~
 
-## On-demand services with fixed stops
-On-demand services with fixed stops is used to model demand responsive services that allow pick up and/or drop off at any location within a group of stops for users that book a trip. These groups of stops are defined using `location_groups.txt` and `location_group_stops.txt`
+## Fixed-Stops Demand Responsive Services
+Fixed-Stops Demand Responsive Services is used to model services that allow pick up and/or drop off at any location within a group of pre-defined stops for users that book a trip. These groups of stops are defined using `location_groups.txt` and `location_group_stops.txt`.
 
 **Pre-requirement**: 
 
 - [Base features](/getting_started/features/base)
-- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) recommended if service requires booking
+- [Booking rules feature](/getting_started/features/flexible_services/#booking-rules) if the service requires booking
 
 | Files included                   | Fields included   |
 |----------------------------------|-------------------|
@@ -253,7 +260,7 @@ On-demand services with fixed stops is used to model demand responsive services 
 ??? note "Sample Data"
 
     <p style="font-size:16px">
-    The following sample defines a service that can pick-up and drop off pre-booked riders at 4 different stops between 7am and 10am.
+    The following sample shows a service that can pick-up and drop off pre-booked riders at 4 different stops between 7am and 10am.
 
     </p>
     !!! note ""


### PR DESCRIPTION
This PR adds the following content to the Flexible services features page:

- Booking rules feature
- Predefined routes with deviation feature
- On-demand services with zones feature
- On-demand services with fixed stops
- Pre-requirements for all features (with special note for 3 features regarding booking_rules)
- Data samples for all features.

Could you take a look @tzujenchanmbd @isabelle-dr? both in terms of content and rendering if possible. Thanks!