### PR TITLE
Update navigation for Community section

### DIFF
--- a/docs/community/spec_amendment_process/gtfs_realtime_amendment_process.md
+++ b/docs/community/spec_amendment_process/gtfs_realtime_amendment_process.md
@@ -1,7 +1,11 @@
-<a class="pencil-link" href="https://github.com/google/transit/edit/master/gtfs-realtime/CHANGES.md" title="Edit this page" target="_blank">
-    <svg class="pencil" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 20H6V4h7v5h5v3.1l2-2V8l-6-6H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h4v-2m10.2-7c.1 0 .3.1.4.2l1.3 1.3c.2.2.2.6 0 .8l-1 1-2.1-2.1 1-1c.1-.1.2-.2.4-.2m0 3.9L14.1 23H12v-2.1l6.1-6.1 2.1 2.1Z"></path></svg>
-  </a>
-  
+# GTFS Realtime
+
+The GTFS Realtime Specification is not set in stone. Instead, it is an open specification developed and maintained by the community of transit agencies, developers, and other stakeholders who use GTFS Realtime. It is expected that this community of producers and consumers of GTFS Realtime data will have proposals for extending the spec to enable new capabilities. To help manage that process, the following procedures and guidelines have been established.
+
+!!! note ""
+
+	The official specification, reference and documentation are written in English. If a translation to a different language differs from the English original, the latter takes precedence. All communication is performed in English.
+
 # Adding new fields to GTFS Realtime
 
 When a producer or consumer is interested in adding a new field to the GTFS Realtime specification, they should open a new issue on the [GTFS Realtime GitHub repository](https://github.com/google/transit) describing the proposed field and announce this new field (including a link to the issue) on the [GTFS Realtime mailing list](https://groups.google.com/forum/#!forum/gtfs-realtime).

--- a/docs/community/spec_amendment_process/gtfs_schedule_amendment_process.md
+++ b/docs/community/spec_amendment_process/gtfs_schedule_amendment_process.md
@@ -1,13 +1,12 @@
-<a class="pencil-link" href="https://github.com/google/transit/edit/master/gtfs/CHANGES.md" title="Edit this page" target="_blank">
-    <svg class="pencil" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M10 20H6V4h7v5h5v3.1l2-2V8l-6-6H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h4v-2m10.2-7c.1 0 .3.1.4.2l1.3 1.3c.2.2.2.6 0 .8l-1 1-2.1-2.1 1-1c.1-.1.2-.2.4-.2m0 3.9L14.1 23H12v-2.1l6.1-6.1 2.1 2.1Z"></path></svg>
-  </a>
-  
-# Specification amendment process
+# GTFS Schedule
+ 
 The GTFS Specification is not set in stone. Instead, it is an open specification developed and maintained by the community of transit agencies, developers, and other stakeholders who use GTFS. It is expected that this community of producers and consumers of GTFS data will have proposals for extending the spec to enable new capabilities. To help manage that process, the following procedures and guidelines have been established.
 
 !!! note ""
 
 	The official specification, reference and documentation are written in English. If a translation to a different language differs from the English original, the latter takes precedence. All communication is performed in English.
+
+# Specification amendment process
 
 1. Create a git branch with update of all relevant parts of protocol definition, specification and documentation files (except for translations).
 1. Create pull request on https://github.com/google/transit. Pull request must contain an extended description of the patch. The creator of the pull request becomes the _advocate_.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,6 +186,10 @@ nav:
     - Active projects: 
       - Fares v2: community/active_projects/fares-v2.md
       - Flex: community/active_projects/flex.md
+      - Trip Modifications: community/active_projects/trip_modifications.md
+    - Specification Amendment Process:
+      - GTFS Schedule Amendment Process: community/spec_amendment_process/gtfs_schedule_amendment_process.md
+      - GTFS Realtime Amendment Process: community/spec_amendment_process/gtfs_realtime_amendment_process.md
   - Resource Library:
     - Resource Library: resource_library/overview.md
     - Guides and Tutorials: resource_library/tutorials.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,7 +186,6 @@ nav:
     - Active projects: 
       - Fares v2: community/active_projects/fares-v2.md
       - Flex: community/active_projects/flex.md
-      - Trip Modifications: community/active_projects/trip_modifications.md
     - Specification Amendment Process:
       - GTFS Schedule Amendment Process: community/spec_amendment_process/gtfs_schedule_amendment_process.md
       - GTFS Realtime Amendment Process: community/spec_amendment_process/gtfs_realtime_amendment_process.md


### PR DESCRIPTION
This change:

- Migrates the Specification Amendment Process for both Schedule and Realtime 
- Adds a new page (currently blank) for Trip Modifications under Active Projects

@eliasmbd do you mind continuing this PR by populating the content in the Trip Modifications page? Thanks!