### PR TITLE
Re-write why_use_GTFS.md and additional recommendation

### DIFF
--- a/docs/getting_started/why_use_GTFS.md
+++ b/docs/getting_started/why_use_GTFS.md
@@ -1,104 +1,51 @@
 # Reach more riders and improve public transit with GTFS
-GTFS, the open-source standard for transit data, empowers you to make public transportation more accessible and efficient.
-
 GTFS serves as the backbone of modern transit systems, enabling agencies to provide accurate and up-to-date information to riders, app developers, and policymakers. Below, we'll explore the various benefits of GTFS and how it enhances public transit worldwide.
 
-## GTFS: More Than Just Trip Planning
-
-While trip planning is a core function, GTFS offers additional features that enhance the transit experience:
-
-- **Fares:** GTFS can include fare information for accurate cost breakdowns across routes and journey options.
-- **Flexible services:** GTFS can describe demand-responsive options like dial-a-ride, route deviations and, other services that do not follow the common behavior of scheduled and/or fixed service.
-- **Pathways:** GTFS can model large transit stations, helping riders navigate from station entrances and exists to the location where they board or disambark from a transit vehicle.
-
-<div class="grid cards" markdown>
-
--   :material-train:{ .lg .middle } __What else GTFS can do?__
-
-
-    [:octicons-arrow-right-24: Learn more](../features/overview)
-
-</div>
-
-## Improved Rider Experience
-
-GTFS empowers riders with accurate schedules, real-time updates, and a wider choice of apps, leading to reduced wait times and informed travel decisions. Here's how GTFS enhances the rider experience:
-
-- **Up-to-Date Information:** GTFS provides riders with access to real-time schedules, routes, and stop information, facilitating informed travel decisions.
-- **Reduced Wait Times:** Real-time information (GTFS Realtime) offers live updates on vehicle locations, reducing wait times and enhancing the overall travel experience.
-- **Wider App Choice:** Access to GTFS data enables riders to choose from a variety of transit apps, ensuring they find the app that best suits their needs and preferences.
-
-<div class="grid cards" markdown>
-
--   :material-bus-alert:{ .lg .middle } __Benefits of Realtime Information (RTI)__
-
-
-    [:octicons-arrow-right-24: Learn more](https://realtimetransit.info/)
-
-</div>
-
-## Global Reach & Seamless Trips
+## Widely Used & Globally Adopted
 
 Over 10,000 agencies in 100+ countries use GTFS, ensuring consistent data for multi-agency trips and simplifying travel across regions. Here's how GTFS facilitates global reach and seamless trips:
 
 - **Standardized Data:** GTFS provides a standardized format for transit data, ensuring consistency across agencies and regions, simplifying travel planning for riders.
 - **Multi-Agency Trips:** GTFS enables agencies to share consistent, reliable data, facilitating seamless travel experiences for riders traveling across multiple transit systems.
 
-## Simplified Data Sharing
+## Community-Driven Development and Freely Accessible
+
+GTFS thrives on community collaboration, ensuring its continuous evolution and relevance, with a primary focus on passenger-facing information within the specification.
+
+- **Open Collaboration:** GTFS operates as an open data standard, allowing anyone to contribute changes or improvements.
+- **Guided Evolution:** The specification evolution is overseen by an independent nonprofit organization called [MobilityData](https://mobilitydata.org/), and its changes are guided by the principles of ease of use, backwards-compatibility, and pragmatic change. 
+- **Community-driven Development:** The GTFS specification undergoes continuous refinement through input and review from the community, facilitated on platforms like [GitHub](https://github.com/) and [Slack](https://share.mobilitydata.org/slack).
+
+[:material-chat-processing: Get Involved](../../community/get_involved){ .md-button }
+[:material-map-plus: Active Projects](../../community/get_involved/#active-projects){ .md-button }
+[:material-book-heart: Guiding Principles](../../community/spec_amendment_process/gtfs_schedule_amendment_process/#guiding-principles){ .md-button }
+
+## Simple and Easy to Use
 
 GTFS fosters collaboration between transit agencies by enabling easy data exchange, promoting smoother service integration, and information sharing. Here's how GTFS simplifies data sharing:
 
-- **Collaborative Development:** GTFS is collaboratively developed, ensuring the format remains relevant to meet the evolving needs of riders and agencies.
 - **Ease of Integration:** GTFS makes it easy for agencies to get started with a simple data structure using common file formats like .txt and GeoJSON, fostering collaboration and interoperability.
 
-## Wider User Base for Apps & Services
+## GTFS can probably do more than you think
+
+While trip planning is a core function, GTFS offers additional features that enhance the transit experience:
+
+- **Fares:** GTFS can include fare information for accurate cost breakdowns across routes and journey options.
+- **Flexible services:** GTFS can describe demand-responsive options like dial-a-ride, route deviations, and other services that do not follow the common behavior of scheduled and/or fixed service.
+- **Pathways:** GTFS can model large transit stations, helping riders navigate from station entrances and exits to the location where they board or disembark from a transit vehicle.
+
+[:octicons-search-16: Learn more about GTFS Features](../features/overview){ .md-button }
+
+## Improved Rider Experience
+
+GTFS empowers riders with accurate schedules, real-time updates, and a wider choice of apps, leading to reduced wait times and informed travel decisions. Here's how GTFS enhances the rider experience:
+
+- **Up-to-Date Information:** GTFS provides riders with access to schedules, routes, and stop information, facilitating informed travel decisions.
+- **Reduced Wait Times:** GTFS Realtime offers live updates on vehicle locations, reducing wait times and enhancing the overall travel experience.
+
+## Access to a Wide Range of Applications
 
 By adopting GTFS, agencies reach a wider audience through the vast pool of app developers utilizing the standardized data format. Here's how GTFS expands the user base for apps and services:
 
 - **Expanded App Reach:** Access to GTFS data allows app developers to reach a wider audience of transit riders, enhancing the usability and functionality of transit apps.
 - **Interoperability:** Open standards facilitate seamless data exchange between transit agencies and app developers, promoting interoperability and collaboration.
-
-## Open Data: More Opportunity and Choices
-
-Unlocking the potential of open data, GTFS offers numerous benefits for both agencies and riders:
-
-- **Wide Accessibility:** GTFS serves as an Open Standard, enabling agencies to easily share transit information through various tools supporting GTFS.
-- **Diverse Applications:** This fosters a broad spectrum of applications and services, ranging from popular trip planners to innovative solutions.
-- **Rider Empowerment:** Riders enjoy the freedom to choose the app that best fits their needs, whether prioritizing accessibility features, simplicity, or cutting-edge innovation.
-
-## Maintained by the Community
-
-GTFS thrives on community collaboration, ensuring its continuous evolution and relevance:
-
-- **Open Collaboration:** GTFS operates as an open data standard, allowing anyone to contribute changes or improvements.
-- **Guided Evolution:** The specification evolution is overseen by an independent nonprofit organization called [MobilityData](https://mobilitydata.org/), and its changes are guided by the principles of ease of use, backwards-compatibility, and pragmatic change. The specification is primarily concerned with passenger information.
-- **Community-driven Development:** The GTFS specification undergoes continuous refinement through input and review from the community, facilitated on platforms like [GitHub](https://github.com/) and [Slack](https://share.mobilitydata.org/slack).
-
-<div class="grid cards" markdown>
-
--   :material-chat-processing:{ .lg .middle } __Get Involved__
-
-
-    [:octicons-arrow-right-24: Learn more](../../community/get_involved)
-
-
- -   :material-map-plus:{ .lg .middle } __Active Projects__
-
-
-    [:octicons-arrow-right-24: Learn more](../../community/get_involved/#active-projects)
-
-
- -   :material-book-heart:{ .lg .middle } __Guiding Principles__
-
-
-    [:octicons-arrow-right-24: Learn more](../../community/spec_amendment_process/gtfs_schedule_amendment_process/#guiding-principles)
-
-</div>
-
-## Continue Learning
-<div class="grid cards" markdown>
-
-- :material-skip-previous: [Go to Previous Section: What is GTFS?](../what_is_GTFS)
-- [Go to Next Section: How to produce GTFS?](../create) :material-skip-next:
-
-</div>

--- a/docs/getting_started/why_use_GTFS.md
+++ b/docs/getting_started/why_use_GTFS.md
@@ -25,6 +25,7 @@ GTFS thrives on community collaboration, ensuring its continuous evolution and r
 GTFS fosters collaboration between transit agencies by enabling easy data exchange, promoting smoother service integration, and information sharing. Here's how GTFS simplifies data sharing:
 
 - **Ease of Integration:** GTFS makes it easy for agencies to get started with a simple data structure using common file formats like .txt and GeoJSON, fostering collaboration and interoperability.
+- **Backwards compatible:** when updating the specification, existing feeds remain valid and maintain compatibility with existing parsers.
 
 ## GTFS can probably do more than you think
 

--- a/docs/getting_started/why_use_GTFS.md
+++ b/docs/getting_started/why_use_GTFS.md
@@ -1,42 +1,104 @@
-# Why Use GTFS?
+# Reach more riders and improve public transit with GTFS
+GTFS, the open-source standard for transit data, empowers you to make public transportation more accessible and efficient.
 
-Over 10,000 transit agencies in 100+ countries rely on GTFS, quickly becoming an industry standard. Here's what makes it so advantageous:
+GTFS serves as the backbone of modern transit systems, enabling agencies to provide accurate and up-to-date information to riders, app developers, and policymakers. Below, we'll explore the various benefits of GTFS and how it enhances public transit worldwide.
 
-- **Simple**: The core GTFS data is text-based and easy to understand. 
-- **Flexible**: It also offers the possibility of plugging in additional features beyond schedules, like fare information, flexible services, and accessibility information.
-- **Open Source**: by being freely available, data can be shared easily, and developers can create tools, shaping the future of GTFS to better suit their needs.
-- **Community Driven**: developed collaboratively, GTFS ensures the format meets the evolving needs of riders and agencies.
+## GTFS: More Than Just Trip Planning
 
-## A simple standard that is accessible to everyone
+While trip planning is a core function, GTFS offers additional features that enhance the transit experience:
 
-Because it is a simple, text-based [Open Standard](https://www.interoperablemobility.org/definitions/#open_standard), many transit technology vendors can already read and write to GTFS files. By easily understanding GTFS, agencies can make better choices when it comes to data making its implementation easier. 
+- **Fares:** GTFS can include fare information for accurate cost breakdowns across routes and journey options.
+- **Flexible services:** GTFS can describe demand-responsive options like dial-a-ride, route deviations and, other services that do not follow the common behavior of scheduled and/or fixed service.
+- **Pathways:** GTFS can model large transit stations, helping riders navigate from station entrances and exists to the location where they board or disambark from a transit vehicle.
 
-## GTFS can probably do more than you think
+<div class="grid cards" markdown>
 
-GTFS is mostly known for providing schedule information for public transit, particularly in metro areas with fixed-route services. However, there are optional features beyond the basic GTFS Schedule such as:
+-   :material-train:{ .lg .middle } __What else GTFS can do?__
 
-- [Fares features](/getting_started/features/fares) showing fare costs and structures; 
-- [Flexible services features](/getting_started/features/flexible_services), offering demand-responsive transit options, like dial-a-ride and paratransit services; 
-- [Pathways features](/getting_started/features/pathways), displaying vital accessibility information for rider navigation in stations. 
-- And [many more](/getting_started/features/overview).
 
-Additionally, GTFS data is now being used by a variety of software applications including data visualization and analysis tools for planning and research. Having up-to-date and high quality data provides accurate transit information not just to riders, but also to planners and policymakers who are able to better understand how transit is being used in their communities. 
+    [:octicons-arrow-right-24: Learn more](../features/overview)
 
-## Open Data means more opportunity and choices
+</div>
 
-GTFS is an Open Standard. This means that agencies can make information available using any of the tools which already support GTFS (including simple text editing or a spreadsheet). Open standards lead to the creation of data that can be easily shared. The feeds can be used by trip planners such as Google, Apple, Transit App, Open Trip Planner, and even apps created by riders. Anyone who wants to provide accurate and up-to-date transit information can use GTFS feed to do so.
+## Improved Rider Experience
 
-Some riders like to use different apps depending on their needs—having GTFS lets riders choose what trip planning app suits them best. Some apps may be more accessible or better at providing information for riders with disabilities, some may be simpler and easier to use, and sometimes riders just want the newest app.
+GTFS empowers riders with accurate schedules, real-time updates, and a wider choice of apps, leading to reduced wait times and informed travel decisions. Here's how GTFS enhances the rider experience:
 
-## Maintained by the community
+- **Up-to-Date Information:** GTFS provides riders with access to real-time schedules, routes, and stop information, facilitating informed travel decisions.
+- **Reduced Wait Times:** Real-time information (GTFS Realtime) offers live updates on vehicle locations, reducing wait times and enhancing the overall travel experience.
+- **Wider App Choice:** Access to GTFS data enables riders to choose from a variety of transit apps, ensuring they find the app that best suits their needs and preferences.
 
-As an open data standard, GTFS is driven by an open community where anyone can propose changes or improvements. The specification evolution is overseen by an independent nonprofit organization called [MobilityData](https://mobilitydata.org/), and its changes are guided by the following principles:
+<div class="grid cards" markdown>
 
-- Feeds should be easy to create and edit
-- Feeds should be easy to parse
-- The specification is primarily concerned with passenger information
-- Changes to the specification should be backwards-compatible
-- Speculative features are discouraged
+-   :material-bus-alert:{ .lg .middle } __Benefits of Realtime Information (RTI)__
 
-The Reference documents for [GTFS Schedule](/documentation/schedule/reference/) and [GTFS Realtime](/documentation/Realtime/reference/) are officially hosted in a [GitHub repository](https://github.com/google/transit), where changes are proposed and reviewed by the community.
 
+    [:octicons-arrow-right-24: Learn more](https://realtimetransit.info/)
+
+</div>
+
+## Global Reach & Seamless Trips
+
+Over 10,000 agencies in 100+ countries use GTFS, ensuring consistent data for multi-agency trips and simplifying travel across regions. Here's how GTFS facilitates global reach and seamless trips:
+
+- **Standardized Data:** GTFS provides a standardized format for transit data, ensuring consistency across agencies and regions, simplifying travel planning for riders.
+- **Multi-Agency Trips:** GTFS enables agencies to share consistent, reliable data, facilitating seamless travel experiences for riders traveling across multiple transit systems.
+
+## Simplified Data Sharing
+
+GTFS fosters collaboration between transit agencies by enabling easy data exchange, promoting smoother service integration, and information sharing. Here's how GTFS simplifies data sharing:
+
+- **Collaborative Development:** GTFS is collaboratively developed, ensuring the format remains relevant to meet the evolving needs of riders and agencies.
+- **Ease of Integration:** GTFS makes it easy for agencies to get started with a simple data structure using common file formats like .txt and GeoJSON, fostering collaboration and interoperability.
+
+## Wider User Base for Apps & Services
+
+By adopting GTFS, agencies reach a wider audience through the vast pool of app developers utilizing the standardized data format. Here's how GTFS expands the user base for apps and services:
+
+- **Expanded App Reach:** Access to GTFS data allows app developers to reach a wider audience of transit riders, enhancing the usability and functionality of transit apps.
+- **Interoperability:** Open standards facilitate seamless data exchange between transit agencies and app developers, promoting interoperability and collaboration.
+
+## Open Data: More Opportunity and Choices
+
+Unlocking the potential of open data, GTFS offers numerous benefits for both agencies and riders:
+
+- **Wide Accessibility:** GTFS serves as an Open Standard, enabling agencies to easily share transit information through various tools supporting GTFS.
+- **Diverse Applications:** This fosters a broad spectrum of applications and services, ranging from popular trip planners to innovative solutions.
+- **Rider Empowerment:** Riders enjoy the freedom to choose the app that best fits their needs, whether prioritizing accessibility features, simplicity, or cutting-edge innovation.
+
+## Maintained by the Community
+
+GTFS thrives on community collaboration, ensuring its continuous evolution and relevance:
+
+- **Open Collaboration:** GTFS operates as an open data standard, allowing anyone to contribute changes or improvements.
+- **Guided Evolution:** The specification evolution is overseen by an independent nonprofit organization called [MobilityData](https://mobilitydata.org/), and its changes are guided by the principles of ease of use, backwards-compatibility, and pragmatic change. The specification is primarily concerned with passenger information.
+- **Community-driven Development:** The GTFS specification undergoes continuous refinement through input and review from the community, facilitated on platforms like [GitHub](https://github.com/) and [Slack](https://share.mobilitydata.org/slack).
+
+<div class="grid cards" markdown>
+
+-   :material-chat-processing:{ .lg .middle } __Get Involved__
+
+
+    [:octicons-arrow-right-24: Learn more](../../community/get_involved)
+
+
+ -   :material-map-plus:{ .lg .middle } __Active Projects__
+
+
+    [:octicons-arrow-right-24: Learn more](../../community/get_involved/#active-projects)
+
+
+ -   :material-book-heart:{ .lg .middle } __Guiding Principles__
+
+
+    [:octicons-arrow-right-24: Learn more](../../community/spec_amendment_process/gtfs_schedule_amendment_process/#guiding-principles)
+
+</div>
+
+## Continue Learning
+<div class="grid cards" markdown>
+
+- :material-skip-previous: [Go to Previous Section: What is GTFS?](../what_is_GTFS)
+- [Go to Next Section: How to produce GTFS?](../create) :material-skip-next:
+
+</div>

--- a/docs/getting_started/why_use_GTFS.md
+++ b/docs/getting_started/why_use_GTFS.md
@@ -28,7 +28,7 @@ GTFS fosters collaboration between transit agencies by enabling easy data exchan
 
 ## GTFS can probably do more than you think
 
-While trip planning is a core function, GTFS offers additional features that enhance the transit experience:
+While schedule information is at its core, GTFS also offers additional features that enhance the transit experience, such as:
 
 - **Fares:** GTFS can include fare information for accurate cost breakdowns across routes and journey options.
 - **Flexible services:** GTFS can describe demand-responsive options like dial-a-ride, route deviations, and other services that do not follow the common behavior of scheduled and/or fixed service.
@@ -38,7 +38,7 @@ While trip planning is a core function, GTFS offers additional features that enh
 
 ## Improved Rider Experience
 
-GTFS empowers riders with accurate schedules, real-time updates, and a wider choice of apps, leading to reduced wait times and informed travel decisions. Here's how GTFS enhances the rider experience:
+Here's how GTFS empowers riders and enhances their experience:
 
 - **Up-to-Date Information:** GTFS provides riders with access to schedules, routes, and stop information, facilitating informed travel decisions.
 - **Reduced Wait Times:** GTFS Realtime offers live updates on vehicle locations, reducing wait times and enhancing the overall travel experience.


### PR DESCRIPTION
Re-wrote this page to make is consistent with landing page language and logic
- Added more bullets points for easier readability and quicker knowledge memorization by reader. 
- Added links where useful
- Added Continue Learning Section (recommend for other getting started pages)

Here are some screenshots of what it looks like: 

Full page
![127 0 0 1_8000_getting_started_why_use_GTFS_ (2)](https://github.com/MobilityData/elrond.gtfs.org/assets/130911698/0a138974-661c-4571-8f4b-892d89ce021a)

Continue Learning Part
<img width="1139" alt="Screenshot 2024-05-28 at 12 24 03 PM" src="https://github.com/MobilityData/elrond.gtfs.org/assets/130911698/778d1037-3f59-46e6-91fd-462a650ffaff">

