### PR TITLE
Update protobuf page and add proto file

### DIFF
--- a/docs/documentation/Realtime/gtfs-realtime.proto
+++ b/docs/documentation/Realtime/gtfs-realtime.proto
@@ -1,7 +1,3 @@
-# GTFS Realtime Protobuf
-Download the [gtfs-realtime.proto](gtfs-realtime.proto) file and use it to compile your GTFS-realtime feed. The contents of the file are shown inline below.
-For more information about using protobufs, see the [Protocol Buffers Developer Guide](https://developers.google.com/protocol-buffers/docs/overview).
-```protobuf
 // Copyright 2015 The GTFS Specifications Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1193,5 +1189,3 @@ message ReplacementStop {
   // The following extension IDs are reserved for private use by any organization.
   extensions 9000 to 9999;
 }
-```
-


### PR DESCRIPTION
This PR updates the Protobuf page and adds an up-to-date proto file, matching the [content hosted in google/transit](https://github.com/google/transit/blob/master/gtfs-realtime/proto/gtfs-realtime.proto), which now includes Trip Modifications.

Do you mind having a look @tzujenchanmbd ?