### PR TITLE
Add note in resources section

### DIFF
--- a/docs/en/resources/overview.md
+++ b/docs/en/resources/overview.md
@@ -1,5 +1,10 @@
 # Resources overview
 
+!!! info "This section is under review" 
+
+        This section currently mirrors the content of the awesome-transit list, please be aware that some external links might be outdated. To provide feedback on the contents of this list, please open an issue or pull request in the [awesome-transit repository](https://github.com/MobilityData/awesome-transit). A reviewed version of this section will be released in the future.
+
+
 ### Community list of transit APIs, apps, datasets, research, and software :bus::star2::train::star2::steam_locomotive:
 
 Have something to add or change? Open a [pull request](https://github.com/CUTR-at-USF/awesome-transit/pulls) or [issue](https://github.com/CUTR-at-USF/awesome-transit/issues) at [MobilityData/awesome-transit](https://github.com/CUTR-at-USF/awesome-transit).


### PR DESCRIPTION
Following PR #91 I'm adding a note in the overview of the Resources section to indicate that the content is under review.

![Screenshot 2024-07-04 at 5 45 19 PM](https://github.com/MobilityData/elrond.gtfs.org/assets/104692200/1cc00e88-097e-4b25-aa7f-b6bcf81c0ff1)


Could you do a quick review and approve if you agree @tzujenchanmbd? Thanks!