### PR TITLE
Add translation notice

### DIFF
--- a/docs/en/about/index.md
+++ b/docs/en/about/index.md
@@ -8,6 +8,11 @@ Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for purchasin
 
 To propose edits to the content of this website, contact MobilityData at [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org) or visit the [GTFS.org GitHub Repository](https://github.com/mobilitydata/gtfs.org) to submit your edits as pull requests.
 
+Regarding translations, GTFS.org uses an automated tool to ensure translations are kept up to date with repository changes. Since our priority is to keep translations up-to-date, any one-time translation contribution will be overwritten in the future. 
+
+We do accept glossary changes for key terms that are commonly used across GTFS.org, like trip or station. If you want to suggest a translation for a key term that should be applied across the entire site, you can create an issue on the [GTFS.org GitHub Repository](https://github.com/mobilitydata/gtfs.org).
+
+
 ## GTFS evolution
 
 GTFS started with a collaboration between TriMet in Portland, Oregon, and Google. TriMet worked with Google to format their transit data into an easily maintainable and consumable format that could be imported into Google Maps. This transit data format was originally known as the Google Transit Feed Specification (GTFS).

--- a/docs/en/about/index.md
+++ b/docs/en/about/index.md
@@ -8,7 +8,7 @@ Thank you to [Andrew Byrd](https://www.linkedin.com/in/byrdandrew) for purchasin
 
 To propose edits to the content of this website, contact MobilityData at [documentation@mobilitydata.org](mailto:documentation@mobilitydata.org) or visit the [GTFS.org GitHub Repository](https://github.com/mobilitydata/gtfs.org) to submit your edits as pull requests.
 
-Regarding translations, GTFS.org uses an automated tool to ensure translations are kept up to date with repository changes. Since our priority is to keep translations up-to-date, any one-time translation contribution will be overwritten in the future. 
+Regarding translations, GTFS.org uses an automated tool to ensure translations are kept up to date with repository changes. Please note that since our priority is to keep translations up-to-date, any translation corrected manually in any language will eventually be overwritten.
 
 We do accept glossary changes for key terms that are commonly used across GTFS.org, like trip or station. If you want to suggest a translation for a key term that should be applied across the entire site, you can create an issue on the [GTFS.org GitHub Repository](https://github.com/mobilitydata/gtfs.org).
 


### PR DESCRIPTION
This PR adds two new paragraphs in the about page to explain that translations are automated and that translation contributions should be limited to glossary suggestions. 

@fredericsimard can you have a look? feel free to adjust as you see fit. Thanks!