### PR TITLE
Fix notice formatting in resources overview

### DIFF
--- a/docs/en/resources/overview.md
+++ b/docs/en/resources/overview.md
@@ -2,7 +2,7 @@
 
 !!! info "This section is under review" 
 
-        This section currently mirrors the content of the awesome-transit list, please be aware that some external links might be outdated. To provide feedback on the contents of this list, please open an issue or pull request in the [awesome-transit repository](https://github.com/MobilityData/awesome-transit). A reviewed version of this section will be released in the future.
+    This section currently mirrors the content of the awesome-transit list, please be aware that some external links might be outdated. To provide feedback on the contents of this list, please open an issue or pull request in the [awesome-transit repository](https://github.com/MobilityData/awesome-transit). A reviewed version of this section will be released in the future.
 
 
 ### Community list of transit APIs, apps, datasets, research, and software :bus::star2::train::star2::steam_locomotive:


### PR DESCRIPTION
Small fix to correct the display of the notice at the top of the Resources overview page. @fredericsimard can you review/approve to see if it works on the live website? Thanks!