### PR TITLE
Fix text formatting in Schedule examples for ES & FR

### DIFF
--- a/docs/es/documentation/schedule/examples/fares-v2.md
+++ b/docs/es/documentation/schedule/examples/fares-v2.md
@@ -124,7 +124,7 @@
  * El área de llegada es `GLEN` 
  * El producto de tarifa para el área de salida/llegada es `BA:matrix:ASHB-GLEN` 
  
- [** fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
+ [**fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
  
  | leg_group_id | from_area_id|to_area_id|fare_product_id|
 |--------------|-----------|------------|---------------|
@@ -159,7 +159,7 @@
  
  `Clipper` se describe como una tarjeta de transporte física con `fare_media_type=2`. `SFMTA Munimobile` se describe como una aplicación móvil con `fare_media_type=2`. El `efectivo` no tiene ningún medio de pago, ya que se entrega directamente al conductor sin necesidad de billete. Como resultado, `Cash` es `fare_media_type=0`. 
  
- [** fare_media.txt**](../../reference/#fare_mediatxt) 
+ [**fare_media.txt**](../../reference/#fare_mediatxt) 
  
 | fare_media_id | fare_media_name  | fare_media_type |
 |---------------|------------------|-----------------|
@@ -227,7 +227,7 @@
  
  El producto de tarifa de viaje único que se muestra a continuación tiene opciones de medios de tarifa "efectivo" y "tap-to-ride". Cuando el viaje sencillo se paga con la tarifa "tap-to-ride", es un dólar más barato. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id | fare_product_name  | fare_media_id | amount | currency |
 |---------------|------------------|---------------|--------|----------|

--- a/docs/es/documentation/schedule/examples/flex.md
+++ b/docs/es/documentation/schedule/examples/flex.md
@@ -85,7 +85,7 @@
  
  El uso de `booking_type = 2` indica que el servicio requiere reserva hasta el día(s) anterior(es). `prior_notice_last_day = 1` y `prior_notice_start_day = 14` indican que el servicio se puede reservar con 14 días de antelación y hasta el día anterior. 
  
- [** booking_rules.txt**](../../reference/#booking_rulestxt) 
+ [**booking_rules.txt**](../../reference/#booking_rulestxt) 
  
  booking_rule_id | booking_type | prior_notice_start_day | prior_notice_start_time | prior_notice_last_day | prior_notice_last_time | message | phone_number | info_url
 --|--|--|--|--|--|--|--|-- 
@@ -98,7 +98,7 @@
  - El primer registro con `pickup_type = 2` y `drop_off_type = 1` indica que la recogida de reservas está permitida en la zona. 
  - El segundo registro con `pickup_type = 1` y `drop_off_type = 2` indica que se permite la entrega de reservas en la zona. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -202,7 +202,7 @@ La ruta 476 opera de 17:30 a 22:00 de lunes a viernes y de 8:00 A. m.a 22:00 p.m
 - el primer registro con `pickup_type = 2` y `drop_off_type = 1` indica que se permite la recogida de reservas en el grupo de ubicación. 
 - El segundo registro con `pickup_type = 1` y `drop_off_type = 2` indica que se permite la entrega de reservas en el grupo de ubicación. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_group_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -283,7 +283,7 @@ tripA | Zone3 | 3 | 1 | 2 | 10:00:00 | 18:00:00
  
  **Prohibido** 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | pickup_type | drop_off_type | start_pickup_drop_off_window | end_pickup_drop_off_window
 -- | -- | -- | -- | -- | -- | --

--- a/docs/fr/documentation/schedule/examples/attributions.md
+++ b/docs/fr/documentation/schedule/examples/attributions.md
@@ -6,7 +6,7 @@
  
  Par exemple, Rejseplanen est un moteur de recherche de services ferroviaires et de bus au Danemark. La société publie un ensemble de données GTFS contenant des données provenant de plusieurs agences et fournisseurs, comme indiqué ci-dessous dans [agency.txt](../../reference/#agencytxt). 
  
- [** agency.txt**](../../reference/#agencytxt) 
+ [**agency.txt**](../../reference/#agencytxt) 
  
 ```
 agency_id,agency_name,agency_url,agency_timezone,agency_lang
@@ -18,7 +18,7 @@ agency_id,agency_name,agency_url,agency_timezone,agency_lang
  
  Afin d’attribuer Rejseplanen en tant que producteur de données, le fichier [attributions.txt](../../reference/#attributionstxt) est utilisé, où un ID d’attribution est défini à côté du nom et de l’URL de l’organisation. Les champs `is_producer`, `is_operator` et `is_authority` sont utilisés pour catégoriser Rejseplanen comme indiqué ci-dessous : 
  
- [** attributions.txt**](../../reference/#attributionstxt) 
+ [**attributions.txt**](../../reference/#attributionstxt) 
  
 ```
 attribution_id,organization_name,attribution_url,is_producer,is_operator,is_authority

--- a/docs/fr/documentation/schedule/examples/continuous-stops.md
+++ b/docs/fr/documentation/schedule/examples/continuous-stops.md
@@ -6,7 +6,7 @@
  
  Le fichier [routes.txt](../../reference/#routestxt) permet de décrire ce service à l’aide des champs `continuous_pickup` et `continuous_drop_off`. Les champs sont définis sur `0` pour indiquer que les ramassages et dépôts continus sont autorisés. 
  
- [** routes.txt**](../../reference/#routestxt) 
+ [**routes.txt**](../../reference/#routestxt) 
  
 ```
 route_id,route_short_name,route_long_name,route_type,continuous_pickup,continuous_drop_off
@@ -48,7 +48,7 @@ F,Silver Lakes Market,34.744662,-117.335407
  - Une entrée avec `continuous_pickup=0` indique que les ramassages continus sont autorisés depuis cet arrêt jusqu’à l’arrêt suivant
  - Une entrée avec `continuous_pickup=1` indique que les ramassages continus sont interdits à partir de cet arrêt jusqu’à l’arrêt suivant 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 ```
 trip_id,stop_id,stop_sequence,departure_time,arrival_time,continuous_pickup,continuous_drop_off,timepoint

--- a/docs/fr/documentation/schedule/examples/fares-v1.md
+++ b/docs/fr/documentation/schedule/examples/fares-v1.md
@@ -9,7 +9,7 @@
  
  Ce service peut être représenté à l’aide des fichiers [fare_attributes.txt](../../reference/#fare_attributestxt), [fare_rules.txt](../../reference/#fare_rulestxt) et [transfers.txt](../../reference/#transferstxt). Le premier fichier, [fare_attributes.txt](../../reference/#fare_attributestxt) décrit les tarifs de l’agence, ci-dessous un exemple pour le tarif presto : 
  
- [** fare_attributes.txt**](../../reference/#fare_attributestxt) 
+ [**fare_attributes.txt**](../../reference/#fare_attributestxt) 
  
 ```
 fare_id,price,currency_type,payment_method,transfers,transfer_duration
@@ -25,7 +25,7 @@ presto_fare,3.2,CAD,1,,7200
  
  Pour cela, deux lignes de métro sont définies ci-dessous dans [routes.txt](../../reference/#routestxt) : 
  
- [** routes.txt**](../../reference/#routestxt) 
+ [**routes.txt**](../../reference/#routestxt) 
  
 ```
 agency_id,route_id,route_type
@@ -35,7 +35,7 @@ TTC,Line2,1
  
  Dans cet exemple, les transferts à La station Bloor-Yonge sont modélisés. Pour cela, cette station est modélisée comme deux arrêts distincts, le premier est la station Bloor qui est desservie par la ligne 1, et le second est la station Yonge, qui est desservie par la ligne 2. Les deux ont `zone_id=ttc_subway_stations` afin de regrouper toutes les stations de métro dans une zone tarifaire unique. 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 ```
 stop_id,stop_name,stop_lat,stop_lon,zone_id
@@ -47,7 +47,7 @@ Yonge,Yonge Station,,43.671049,-79.386789,ttc_subway_stations
  
  - Pour `fare_id=presto_fare`, les usagers peuvent voyager entre deux stations de la ligne 1 (`route_id=line1`) et `origin_id=ttc_subway_stations` et `destination_id=ttc_subway_stations`. 
  
- [** fare_rules.txt**](../../reference/#fare_rulestxt) 
+ [**fare_rules.txt**](../../reference/#fare_rulestxt) 
  
 ```
 fare_id,route_id,origin_id,destination_id
@@ -57,7 +57,7 @@ presto_fare,line2,ttc_subway_stations,ttc_subway_stations
  
  Le troisième fichier, [transfers.txt](../../reference/#transferstxt) définit les points de transfert entre les différents itinéraires. Pour modéliser les transferts à la gare de Bloor-Yonge, deux entrées sont requises : 
  
- [** transfers.txt**](../../reference/#transferstxt) 
+ [**transfers.txt**](../../reference/#transferstxt) 
  
 ```
 from_stop_id,to_stop_id,from_route_id,to_route_id,transfer_type

--- a/docs/fr/documentation/schedule/examples/fares-v2.md
+++ b/docs/fr/documentation/schedule/examples/fares-v2.md
@@ -34,7 +34,7 @@
  
  Les billets ou tarifs de transport en commun sont appelés produits tarifaires dans GTFS. Ils peuvent être décrits à l’aide du fichier [fare_products.txt](../../reference/#fare_productstxt). Chaque entrée correspond à un tarif spécifique. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id  | fare_product_name  | amount  | currency  |
 |------------------------|--------------------|---|---|
@@ -54,7 +54,7 @@
  
  Les groupes de trajets tarifaires définissent des trajets au sein d’un réseau depuis une origine vers une destination (ou un ensemble d’origines vers un ensemble de destinations si les identifiants de zone correspondent à des arrêts groupés). Le fichier ci-dessous décrit les règles pour voyager n’importe où au sein du réseau central de la Maryland Transit Administration. Chaque règle correspond à l’un des produits tarifaires réguliers dans [Définir un exemple de tarif de transport](/#definir-un-titre-de-transport). 
  
- [** fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
+ [**fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
  
 |  leg_group_id |  network_id | fare_product_id  |
 |---|---|---|
@@ -71,7 +71,7 @@
  
  Il existe un transfert de 90 minutes pour les passagers qui achètent un aller simple pour emprunter les bus locaux BaltimoreLink, Metro SubwayLink ou Light RailLink. Cela signifie qu’ils peuvent transférer un nombre illimité de fois entre les bus locaux, le métro et le train léger sur rail dans un délai de 90 minutes. 
  
- [** fare_transfer_rules.txt**](../../reference/#fare_transfer_rulestxt) 
+ [**fare_transfer_rules.txt**](../../reference/#fare_transfer_rulestxt) 
  
 | from_leg_group_id       | to_leg_group_id  | duration_limit | duration_limit_type | fare_transfer_type | transfer_count |
 |-------------------------|---|----------------|-------------------|---------------------|----------------|
@@ -101,7 +101,7 @@
  
  Tout d’abord, identifiez la zone dans [areas.txt](../../reference/#areastxt). Il est acceptable de laisser « `area_name` » vide s’il n’y a pas de nom de zone. Dans le tableau ci-dessous, il y a trois `area_id` - `ASHB`, `GLEN` et `OAKL`. 
  
- [** areas.txt**](../../reference/#areastxt) 
+ [**areas.txt**](../../reference/#areastxt) 
  
 | area_id | area_name |
 |---------|-----------|
@@ -127,7 +127,7 @@
  * La zone d’arrivée est `GLEN` 
  * Le produit tarifaire pour la zone de départ/arrivée est `BA:matrix:ASHB-GLEN` 
  
- [** fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
+ [**fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
  
 | leg_group_id | from_area_id|to_area_id|fare_product_id|
 |--------------|-----------|------------|---------------|
@@ -136,7 +136,7 @@
  
  Le tarif est identifié dans `fare_products.txt`. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id     | fare_product_name| amount | currency |
 |---------------------|-----------|--------|----------|
@@ -162,7 +162,7 @@
  
  `Clipper` est décrit comme une carte de transport physique avec `fare_media_type=2`. `SFMTA Munimobile` est décrit comme une application mobile avec `fare_media_type=2`. Le paiement en espèces n’a pas de support tarifaire, puisqu’il est remis directement au conducteur sans ticket. Par conséquent, `Cash` vaut `fare_media_type=0`. 
  
- [** fare_media.txt**](../../reference/#fare_mediatxt) 
+ [**fare_media.txt**](../../reference/#fare_mediatxt) 
  
 | fare_media_id | fare_media_name  | fare_media_type |
 |---------------|------------------|-----------------|
@@ -176,7 +176,7 @@
  
  La <a href="https://www.mbta.com" target="_blank">Massachusetts Bay Transportation Authority (MBTA)</a> permet aux utilisateurs de payer leurs déplacements et leurs pass à l’aide d’un billet papier physique appelé CharlieTicket. Pour refléter cela, il existe un média tarifaire `charlieticket` dans le flux de MBTA avec un `fare_media_type=1`. 
  
- [** fare_media.txt**](../../reference/#fare_mediatxt) 
+ [**fare_media.txt**](../../reference/#fare_mediatxt) 
  
 | fare_media_id | fare_media_name  | fare_media_type |
 |---------------|------------------|-----------------|
@@ -192,7 +192,7 @@
  
  Chaque entrée ci-dessous décrit un support tarifaire. 
  
- [** fare_media.txt**](../../reference/#fare_mediatxt) 
+ [**fare_media.txt**](../../reference/#fare_mediatxt) 
  
 | fare_media_id | fare_media_name  | fare_media_type |
 |---------------|------------------|-----------------|
@@ -201,7 +201,7 @@
  
  L’extrait de fichier `fare_products.txt` ci-dessous montre comment le montant du produit `Muni single local fare` varie en fonction du support tarifaire utilisé par le passager. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id | fare_product_name  | amount | currency | fare_media_id |
 |---------------|------------------|-------|--- |---------------|
@@ -230,7 +230,7 @@
  
  Le produit tarifaire aller simple présenté ci-dessous propose à la fois des options de support tarifaire `cash` et `tap-to-ride`. Lorsque le trajet simple est payé avec le tarif `tap-to-ride`, il coûte un dollar de moins. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id | fare_product_name  | fare_media_id | amount | currency |
 |---------------|------------------|---------------|--------|----------|
@@ -248,7 +248,7 @@
  
  Premièrement, les jours de service sont définis à l’aide de `calendar.txt`. 
  
- [** calendar.txt**](../../reference/#calendartxt) 
+ [**calendar.txt**](../../reference/#calendartxt) 
  
 | service_id       | monday | tuesday | wednesday | thursday | friday | saturday | sunday | start_date | end_date |
 |------------------|--------|---------|-----------|----------|--------|----------|--------|------------|----------|
@@ -259,7 +259,7 @@
  
  Ensuite, les périodes horaires souhaitées sont définies dans `timeframes.txt`, en fournissant un identifiant, les jours applicables via une référence à `calendar.service_id`, et le cas échéant, l’heure de début et l’heure de fin pour chaque période horaire. 
  
- [** timeframes.txt**](../../reference/#timeframestxt) 
+ [**timeframes.txt**](../../reference/#timeframestxt) 
  
 | timeframe_group_id | start_time | end_time | service_id       |
 |--------------------|------------|----------|------------------|
@@ -274,7 +274,7 @@
  
  Ensuite, les tarifs spécifiques à une heure correspondants dans `fare_products.txt` sont créés (par exemple, tarif Peak) 
  
- [** fare_products.txt**](../../reference/#fare_productstxt)
+ [**fare_products.txt**](../../reference/#fare_productstxt)
 
 | fare_product_id | fare_product_name                             | amount | currency |
 |-----------------|-----------------------------------------------|--------|----------|
@@ -286,7 +286,7 @@
  Enfin, les périodes horaires sont associées aux produits tarifaires dans `fare_leg_rules.txt` à l’aide des champs `from_timeframe_group_id` et `to_timeframe_group_id`. Ces champs déterminent si un tarif s’applique uniquement au début du trajet ou à la fois au début et à la fin du trajet. 
  Pour cet exemple, basé sur les tarifs WMATA, le tarif dépend uniquement de l’heure de départ du trajet, donc `to_timeframe_group_id` est laissé vide. 
  
- [** fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
+ [**fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
  
 | network_id | fare_product_id | from_timeframe_group_id | to_timeframe_group_id |
 |------------|-----------------|-------------------------|-----------------------|
@@ -306,7 +306,7 @@
  
  Cet exemple est basé sur un <a href="https://docs.google.com/spreadsheets/d/1-cD-R2OH5xAQAbNWNlrXD7WOw594lVdW-bomuLo6bI8/edit?usp=sharing" target="_blank">ensemble de données</a> produit par <a href="https://www.itoworld.com/" target="_blank">ITO World</a>, présentant un voyage qui utilise dix arrêts répartis dans six zones différentes. 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 | stop_id | stop_name           | stop_lat  | stop_lon   |
 |---------|---------------------|-----------|------------|
@@ -322,7 +322,7 @@
 | ITO2383 | Grand Central       | 40.752823 | -73.977196 |
  
  
- [** stop_areas.txt**](../../reference/#stop_areastxt) 
+ [**stop_areas.txt**](../../reference/#stop_areastxt) 
  
 | area_id   | stop_id |
 |-----------|---------|
@@ -338,14 +338,14 @@
 | mnr_HUD-9 | ITO2096 |
  
  
- [** route_networks.txt**](../../reference/#route_networkstxt) 
+ [**route_networks.txt**](../../reference/#route_networkstxt) 
  
 | network_id | route_id |
 |------------|----------|
 | mnr_hudson | 669      |
  
  
- [** networks.txt**](../../reference/#networkstxt) 
+ [**networks.txt**](../../reference/#networkstxt) 
  
 | network_id | network_name    |
 |------------|-----------------|
@@ -353,7 +353,7 @@
  
  Les jours de service pour les trains 3 et 13 sont définis à l’aide de `calendar.txt`. Notamment, d’autres entrées avec des jours génériques (c’est-à-dire les jours de la semaine, le week-end et n’importe quel jour) qui ne sont associées à aucun voyage sont définies, et celles-ci seront associées à des périodes horaires afin de modéliser des `time-variable fares`. 
  
- [** calendar.txt**](../../reference/#calendartxt) 
+ [**calendar.txt**](../../reference/#calendartxt) 
  
 | service_id | monday | tuesday | wednesday | thursday | friday | saturday | sunday | start_date | end_date |
 |------------|--------|---------|-----------|----------|--------|----------|--------|------------|----------|
@@ -371,7 +371,7 @@
  * Not AM Peak : horaire de la semaine non inclus en AM Peak 
  * Pas AM2PM Peak : heure de la semaine non incluse dans AM2PM Peak 
  
- [** timeframes.txt**](../../reference/#timeframestxt) 
+ [**timeframes.txt**](../../reference/#timeframestxt) 
  
 | timeframe_group_id | start_time | end_time | service_id |
 |:------------------:|:----------:|:--------:|:----------:|
@@ -390,7 +390,7 @@
  
  Chaque produit tarifaire individuel est défini dans `fare_products.txt`. Étant donné que Cold Spring est situé dans la zone 7, cet exemple répertorie uniquement les trajets entre les zones 1 et 7. Le jeu de données complet comprendrait un enregistrement pour chaque prix défini par une combinaison d’heure et de zone. De plus, l’exemple n’affiche qu’un seul support tarifaire (`paper`), mais des combinaisons supplémentaires pourraient être créées si les prix variaient également en fonction du support tarifaire. 
  
- [** fare_products.txt**](../../reference/#fare_productstxt) 
+ [**fare_products.txt**](../../reference/#fare_productstxt) 
  
 | fare_product_id        | fare_product_name                  | fare_media_id | amount | currency |
 |------------------------|------------------------------------|---------------|--------|----------|
@@ -401,7 +401,7 @@
  
  Enfin, les combinaisons de zones d’origine et de destination, ainsi que leurs périodes horaires respectives sont associées au produit tarifaire correspondant dans `fare_leg_rules.txt`. Ici, les voyages commençant ou arrivant dans la zone 1 (c’est-à-dire `area_id=mnr_1`) pendant les heures de pointe sont soumis à un tarif de pointe spécifique correspondant aux zones d’arrivée et de départ du voyage (c’est-à-dire `fare_product_id=mnr_1:HUD-7_adult_peak`). 
  
- [** fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
+ [**fare_leg_rules.txt**](../../reference/#fare_leg_rulestxt) 
  
 | network_id | from_area_id | to_area_id | fare_product_id        | from_timeframe_group_id | to_timeframe_group_id |
 |------------|--------------|------------|------------------------|-------------------------|-----------------------|

--- a/docs/fr/documentation/schedule/examples/feed-info.md
+++ b/docs/fr/documentation/schedule/examples/feed-info.md
@@ -11,7 +11,7 @@
  
  Vous trouverez ci-dessous un exemple de Transport for Cairio : 
  
- [** feed_info.txt**](../../reference/#feed_infotxt) 
+ [**feed_info.txt**](../../reference/#feed_infotxt) 
  
 ```
 feed_publisher_name,feed_publisher_url,feed_lang,feed_start_date,feed_end_date,feed_version

--- a/docs/fr/documentation/schedule/examples/flex.md
+++ b/docs/fr/documentation/schedule/examples/flex.md
@@ -28,7 +28,7 @@
  - Service dans la zone New Ulm de 17h00 à 17h45 en semaine. 
  - Service dans la zone New Ulm de 8h00 à 12h00 le dimanche. 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 route_id | service_id | trip_id
 -- | -- | -- 
@@ -84,7 +84,7 @@ route_id | service_id | trip_id
  
  L’utilisation de `booking_type = 2` indique que le service nécessite une réservation jusqu’au(x) jour(s) précédent(s). `prior_notice_last_day = 1` et `prior_notice_start_day = 14` indiquent que le service peut être réservé dès 14 jours à l’avance et au plus tard la veille. 
  
- [** booking_rules.txt**](../../reference/#booking_rulestxt) 
+ [**booking_rules.txt**](../../reference/#booking_rulestxt) 
  
  booking_rule_id | booking_type | prior_notice_start_day | prior_notice_start_time | prior_notice_last_day | prior_notice_last_time | message | phone_number | info_url
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -97,7 +97,7 @@ booking_route_74362 | 2 | 14 | 8:00:00 | 1 | 15:00:00 | Brown County Heartland E
  - La première entrée avec `pickup_type = 2` et `drop_off_type = 1` indique que la réservation pour une prise en charge est autorisée dans la zone. 
  - La deuxième entrée avec `pickup_type = 1` et `drop_off_type = 2` indique que la réservation pour un dépôt est autorisée dans la zone. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -122,7 +122,7 @@ t_5374947_b_77497_tn_0 | area_715 | 2 | 08:00:00 | 12:45:00 | 1 | 2 | booking_ro
  
  Semblable à l’exemple précédent, car les heures de service varient selon les jours, il est nécessaire de définir les déplacements séparément pour les jours de semaine et les samedis. 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 route_id | service_id | trip_id 
 -- | -- | -- 
@@ -135,7 +135,7 @@ route_id | service_id | trip_id
  
  Les données suivantes indiquent que le ramassage n’est autorisé que dans une zone et le dépôt n’est autorisé que dans une autre zone. Les prises en charge et les dépôts dans la même zone ne sont pas autorisés. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -152,7 +152,7 @@ t_5298041_b_77503_tn_0 | area_714 | 2 | 09:00:00 | 19:00:00 | 1 | 2 | booking_ro
  
 La route 476 offre des services à la demande entre chaque arrêt dans la région d’Angermünde. Ils exploitent deux services (un pour la semaine et l’autre pour le week-end), chacun étant associé à un seul trip_id. 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 route_id | service_id | trip_id 
 -- | -- | -- 
@@ -163,13 +163,13 @@ route_id | service_id | trip_id
  
  Comme les usagers peuvent réserver des services entre chaque arrêt, pour éviter de définir toutes les combinaisons d’arrêt à arrêt dans stop_times.txt, l’approche appropriée consiste à définir ces arrêts en tant qu’emplacement groupe en utilisant location_groups.txt et location_group_stops.txt. 
  
- [** location_groups.txt**](../../reference/#location_groupstxt) 
+ [**location_groups.txt**](../../reference/#location_groupstxt) 
  
 location_group_id | location_group_name 
 -- | -- 
 476_stops | durch den RufBus 476 bedientes Gebiet im Raum Angermünde
  
- [** location_group_stops.txt**](../../reference/#location_group_stopstxt) 
+ [**location_group_stops.txt**](../../reference/#location_group_stopstxt) 
  
 location_group_id | stop_id 
 -- | -- 
@@ -187,7 +187,7 @@ location_group_id | stop_id
  
  Il existe de légères différences entre les réservations en semaine et les réservations le week-end, des règles de réservation distinctes peuvent donc être définies pour les services en semaine et pendant les jours fériés. Plus de détails peuvent être fournis dans le champ `message`. Des liens vers des informations et des pages de réservation peuvent être fournis dans les champs `info_url` et `booking_url`. 
  
- [** booking_rules.txt**](../../reference/#booking_rulestxt) 
+ [**booking_rules.txt**](../../reference/#booking_rulestxt) 
  
 booking_rule_id | booking_type | prior_notice_duration_min | message | phone_number | info_url | booking_url
 -- | -- | -- | -- | -- | -- | --
@@ -201,7 +201,7 @@ flächenrufbus_angermünde_weekends | 1 | 60 | 1€ Komfortzuschlag pro Person; 
  - La première entrée avec `pickup_type = 2` et `drop_off_type = 1` indique que la réservation pour une prise en charge est autorisée dans le groupe d’emplacements. 
  - La deuxième entrée avec `pickup_type = 1` et `drop_off_type = 2` indique que la réservation pour un dépôt est autorisée dans le groupe d’emplacements. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_group_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -222,7 +222,7 @@ trip_id | location_group_id | stop_sequence | start_pickup_drop_off_window | end
  
  Étant donné que ce type de service implique toujours une série d’arrêts fixes et un horaire fixe, la définition des trajets est similaire aux services de bus normaux à itinéraire fixe. Cela nécessite de définir les déplacements desservis par chaque itinéraire tout au long de toutes les périodes de service pertinentes. 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 route_id | service_id | trip_id | share_id
 -- | -- | -- | -- 
@@ -244,7 +244,7 @@ route_id | service_id | trip_id | share_id
  
  Pour les arrêts fixes, définissez des champs tels que `arrival_time`, `departure_time` et `stop_id` d’une manière similaire aux itinéraires de bus normaux. Entre les arrêts fixes, définissez les zones où l’écart est autorisé. `pickup_type = 1` et `drop_off_type = 3` indiquent que la prise en charge déviée n’est pas autorisée (en limitant la prise en charge aux arrêts fixes uniquement) et que les passagers doivent se coordonner avec le conducteur pour être déposés dans la zone de déviation. 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | arrival_time | departure_time | stop_id | location_id | stop_sequence | start_pickup_drop_off_window | end_pickup_drop_off_window | pickup_type | drop_off_type | shape_dist_traveled | pickup_booking_rule_id | drop_off_booking_rule_id
 -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
@@ -280,7 +280,7 @@ tripA | Zone3 | 3 | 1 | 2 | 10:00:00 | 18:00:00
  
  **Interdit** 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | pickup_type | drop_off_type | start_pickup_drop_off_window | end_pickup_drop_off_window
 -- | -- | -- | -- | -- | -- | --
@@ -290,7 +290,7 @@ tripA | vancouver | 3 | 1 | 2 | 10:00:00 | 14:00:00
  
  **Autorisé** 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | pickup_type | drop_off_type | start_pickup_drop_off_window | end_pickup_drop_off_window
 -- | -- | -- | -- | -- | -- | --
@@ -300,7 +300,7 @@ tripA | vancouver | 3 | 1 | 2 | 10:00:00 | 14:00:00
  
  ou 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | pickup_type | drop_off_type | start_pickup_drop_off_window | end_pickup_drop_off_window
 -- | -- | -- | -- | -- | -- | --
@@ -310,7 +310,7 @@ tripA | vancouver | 3 | 1 | 2 | 10:00:00 | 14:00:00
  
  ou 
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 trip_id | location_id | stop_sequence | pickup_type | drop_off_type | start_pickup_drop_off_window | end_pickup_drop_off_window
 -- | -- | -- | -- | -- | -- | --

--- a/docs/fr/documentation/schedule/examples/frequencies.md
+++ b/docs/fr/documentation/schedule/examples/frequencies.md
@@ -4,7 +4,7 @@
  
  La Société de Transport de Montréal exploite des services de transport en commun à Montréal et exploite un service basé sur des fréquences de passage pour ses lignes de métro. Par conséquent, au lieu de fournir un horaire avec les heures d’arrivée et de départ dans un ensemble de données GTFS, le fichier [frequencies.txt](../../reference/#frequenciestxt) est utilisé pour décrire la fréquence du service tout au long de la durée du service. La répétition d’un trajet ne fonctionne que dans les cas où le timing entre les arrêts reste cohérent pour tous les arrêts. Lors de la modélisation d’un service basé sur la fréquence, stop_times.txt (@TODO link) contient les temps relatifs entre les arrêts afin de déterminer les temps à afficher aux passagers. 
  
- [** frequencies.txt**](../../reference/#frequenciestxt) 
+ [**frequencies.txt**](../../reference/#frequenciestxt) 
  
 ```
 trip_id,start_time,end_time,headway_secs

--- a/docs/fr/documentation/schedule/examples/pathways.md
+++ b/docs/fr/documentation/schedule/examples/pathways.md
@@ -63,7 +63,7 @@
  
  Dans un premier temps, l’emplacement de la gare et ses entrées sont définis dans [stops.txt](../../reference/#stopstxt) : 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 ```
 stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,wheelchair_boarding
@@ -83,7 +83,7 @@ stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,wheelchair_boar
  
  L’entrée de la station Waterfront à la rue Granville a un ascenseur, un escalator et des escaliers, les entrées sont définies comme les nœuds ci-dessus dans [stops.txt](../../reference/#stopstxt). Pour connecter les entrées aux sections intérieures de la station, des nœuds supplémentaires doivent être créés dans [stops.txt](../../reference/#stopstxt) sous le `parent_station` de Waterfront Station. Dans le fichier [stops.txt](../../reference/#stopstxt) ci-dessous, les nœuds génériques (`location_type 3`) qui correspondent au bas de l’escalier et de l’escalator sont définis. 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 ```
 stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,wheelchair_boarding
@@ -98,7 +98,7 @@ stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,wheelchair_boar
  
  De même, le deuxième enregistrement décrit l’escalier roulant (`pathway_mode` défini sur `4`). Étant donné que les escaliers mécaniques ne peuvent se déplacer que dans une seule direction, le champ `is_bidirectional` est défini sur `0`, donc l’escalier roulant se déplace dans un sens, du nœud `96` à `91` (vers le haut). 
  
- [** pathways.txt**](../../reference/#pathwaystxt) 
+ [**pathways.txt**](../../reference/#pathwaystxt) 
  
 ```
 pathway_id,from_stop_id,to_stop_id_pathway_mode,is_bidirectional

--- a/docs/fr/documentation/schedule/examples/routes-stops-trips.md
+++ b/docs/fr/documentation/schedule/examples/routes-stops-trips.md
@@ -6,7 +6,7 @@
  
  La première étape consiste à ajouter les informations sur l’agence comme indiqué dans le fichier [agency.txt](../../reference/#agencytxt) ci-dessous. Ce fichier contient des informations de haut niveau sur l’agence. 
  
- [** agency.txt**](../../reference/#agencytxt) 
+ [**agency.txt**](../../reference/#agencytxt) 
  
 ```
 agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone
@@ -15,7 +15,7 @@ CT,Calgary Transit,http://www.calgarytransit.com,America/Edmonton,,403-262-1000
  
  Calgary Transit exploite des services de TLR, de BRT, de bus réguliers, de transport adapté et de transport en commun à la demande dans Calgary, Alberta. Dans cet exemple, deux itinéraires sont définis, le premier est un bus et le second est un LRT. À l’aide du fichier [routes.txt](../../reference/#routestxt), chaque itinéraire se voit attribuer un identifiant unique, ainsi qu’un nom court ainsi qu’un nom long pour une lisibilité humaine. 
  
- [** routes.txt**](../../reference/#routestxt) 
+ [**routes.txt**](../../reference/#routestxt) 
  
 ```
 agency_id,route_id,route_short_name,route_long_name,route_type,route_url,route_color,route_text_color
@@ -37,7 +37,7 @@ CT,202-20666,202,Blue Line - Saddletowne/69 Street CTrain,0,www.calgarytransit.c
  
  Dans GTFS, les arrêts et les gares sont décrits à l’aide du fichier [stops.txt](../../reference/#stopstxt), ci-dessous, un arrêt de bus est défini dans le premier enregistrement et une station LRT est définie dans le deuxième enregistrement. 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 ```
 stop_id,stop_code,stop_name,stop_lat,stop_lon,location_type
@@ -61,7 +61,7 @@ stop_id,stop_code,stop_name,stop_lat,stop_lon,location_type
  
  Tout d’abord, l’étendue du service doit être définie à l’aide de [calendar.txt](../../reference/#calendartxt). 
  
- [** calendar.txt**](../../reference/#calendartxt) 
+ [**calendar.txt**](../../reference/#calendartxt) 
  
 ```
 service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
@@ -72,7 +72,7 @@ weekend_service,0,0,0,0,0,1,1,20220623,20220903
  
  Dans cet exemple, le fichier [trips.txt](../../reference/#tripstxt) décrit 3 voyages de week-end desservis par l’itinéraire MAX Orange décrit ci-dessus. 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 ```
 route_id,service_id,trip_id,trip_headsign,direction_id,shape_id
@@ -92,7 +92,7 @@ route_id,service_id,trip_id,trip_headsign,direction_id,shape_id
  
  Le `shape_id=3030026` correspond au MAX Orange vers Saddletowne. Le fichier ci-dessous comprend des informations sur les points qui délimitent le trajet, ainsi que la distance entre chaque point et le début du trajet. Avec ces informations, il est possible de tracer l’itinéraire sur une carte à des fins de planification de voyage. 
  
- [** shapes.txt**](../../reference/#shapestxt) 
+ [**shapes.txt**](../../reference/#shapestxt) 
  
 ```
 shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
@@ -126,7 +126,7 @@ shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
  
  Cependant, cela complique le fichier puisque `service_id` est cassé en deux et cette rupture se répercutera sur [trips.txt](../../reference/#tripstxt). Au lieu de cela, cela peut être fait de manière plus simple en utilisant [calendar_dates.txt](../../reference/#calendar_datestxt) comme indiqué ci-dessous : 
  
- [** calendar_dates.txt**](../../reference/#calendar_datestxt) 
+ [**calendar_dates.txt**](../../reference/#calendar_datestxt) 
  
 ```
 service_id,date,exception_type

--- a/docs/fr/documentation/schedule/examples/text-to-speech.md
+++ b/docs/fr/documentation/schedule/examples/text-to-speech.md
@@ -10,7 +10,7 @@
  Sinon, le logiciel lirait « 3300 » comme « trois mille trois cents ». 
  - Les ordinaux, tels que 1er, 2e et 3e, doivent être épelés : par exemple, « 1er » devient « premier ». 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 | stop_id | stop_name | tts_stop_name |
 | ---- | ---- | ---- |
@@ -25,7 +25,7 @@
  
  Pour Tampa, le signe « North to UATC » contient un acronyme qui se prononce par ses lettres individuelles. La désambiguïsation de la synthèse vocale serait : 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 | trip_headsign | tts_trip_headsign |
 | ---- | ---- |

--- a/docs/fr/documentation/schedule/examples/transfers.md
+++ b/docs/fr/documentation/schedule/examples/transfers.md
@@ -14,14 +14,14 @@
  
  Par exemple, considérons les valeurs suivantes [trips.txt](../../reference/#tripstxt) et [stop_times.txt](../../reference/#stop_timestxt): 
  
- [** trips.txt**](../../reference/#tripstxt) 
+ [**trips.txt**](../../reference/#tripstxt) 
  
 | route_id | trip_id     | block_id  |
 |----------|-------------|---|
 | RouteA   | RouteATrip1 |  Block1 |
 | RouteB   | RouteBTrip1 |  Block1 |
  
- [** stop_times.txt**](../../reference/#stop_timestxt) 
+ [**stop_times.txt**](../../reference/#stop_timestxt) 
  
 | trip_id | arrival_time     | departure_time | stop_id | stop_sequence |
 |----------|-------------|---|----|-----|

--- a/docs/fr/documentation/schedule/examples/translations.md
+++ b/docs/fr/documentation/schedule/examples/translations.md
@@ -6,7 +6,7 @@
  
  La SNCB publie les données GTFS en français comme indiqué dans le fichier ci-dessous : 
  
- [** agency.txt**](../../reference/#agencytxt) 
+ [**agency.txt**](../../reference/#agencytxt) 
  
 ```
 agency_id,agency_name,agency_url,agency_timezone,agency_lang
@@ -16,7 +16,7 @@ NMBS/SNCB,NMBS/SNCB,http://www.belgiantrain.be/,Europe/Brussels,fr
  
  La langue de l’agence étant le français, les noms des stations sont répertoriés en français dans [stops.txt](../../reference/#stopstxt). 
  
- [** stops.txt**](../../reference/#stopstxt) 
+ [**stops.txt**](../../reference/#stopstxt) 
  
 ```
 stop_id,stop_code,stop_name,stop_desc,stop_lat,stop_lon,zone_id,stop_url,location_type,parent_station,platform_code
@@ -27,7 +27,7 @@ S8821006,,Anvers-Central,,51.2172000,4.42109800,,,1,,
  
  Le fichier [translations.txt](../../reference/#translationstxt) est ensuite utilisé pour traduire les noms des stations de la langue par défaut de l’agence (le français dans ce cas) vers le néerlandais. 
  
- [** translations.txt**](../../reference/#translationstxt) 
+ [**translations.txt**](../../reference/#translationstxt) 
  
 ```
 table_name,field_name,record_id,language,translation
@@ -43,7 +43,7 @@ stops,stop_name,S8815040,nl,Brussel-West
  
  Il existe une autre façon de traduire les noms en GTFS en utilisant le fichier [translations.txt](../../reference/#translationstxt), où le champ `field_value` est utilisé à la place de `record_id`. Dans ce cas, le nom de la station est utilisé pour rechercher l’enregistrement à traduire à partir de [stops.txt](../../reference/#stopstxt). 
  
- [** translations.txt**](../../reference/#translationstxt) 
+ [**translations.txt**](../../reference/#translationstxt) 
  
 ```
 table_name,field_name,field_value,language,translation


### PR DESCRIPTION
I missed a few errors in #104 and also noticed we had the same formatting issue in French. I think I captured all of them now. @fredericsimard can you approve? thanks!